### PR TITLE
Fix bug when g3kb-switch -l cannot work

### DIFF
--- a/g3kb-switch-completion.zsh
+++ b/g3kb-switch-completion.zsh
@@ -3,7 +3,7 @@
 _arguments \
   "(- *)"-v"[Show the program version and exit]" \
   "(- *)"-h"[Show this message and exit]" \
-  "(- *)"-s"[Switch to layout group ARG]:(ARG):($(g3kb-switch -l))" \
+  "(- *)"-s"[Switch to layout group ARG]:(ARG):($(g3kb-switch -l 2> /dev/null))" \
   "(- *)"-n"[Switch to the next layout group]" \
   "(- *)"-l"[Show available layout groups]" \
   "(- *)"-p"[Show the current layout group (default)]" \


### PR DESCRIPTION
Avoid this situation.

```
❯ g3kb-switch -l
Failed to build keyboard layouts map: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.gnome.Shell was not provided by any .service files
```