### PR TITLE
Port extension to GNOME 45

### DIFF
--- a/extension/g3kb-switch@g3kb-switch.org/extension.js
+++ b/extension/g3kb-switch@g3kb-switch.org/extension.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Gio = imports.gi.Gio;
-const Keyboard = imports.ui.status.keyboard;
+import Gio from 'gi://Gio';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Keyboard from 'resource:///org/gnome/shell/ui/status/keyboard.js';
 
 const G3kbSwitchIface = `
 <node>
@@ -22,8 +23,9 @@ const G3kbSwitchIface = `
     </interface>
 </node>`;
 
-class Extension {
-    constructor() {
+export default class G3kbSwitchExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
         this._dbusImpl =
             Gio.DBusExportedObject.wrapJSObject(G3kbSwitchIface, this);
     }
@@ -98,7 +100,4 @@ class Extension {
     }
 }
 
-function init() {
-    return new Extension();
-}
 

--- a/extension/g3kb-switch@g3kb-switch.org/metadata.json
+++ b/extension/g3kb-switch@g3kb-switch.org/metadata.json
@@ -3,14 +3,9 @@
     "description": "G3kbSwitch helper",
     "uuid": "g3kb-switch@g3kb-switch.org",
     "shell-version": [
-        "40",
-        "41",
-        "42",
-        "43",
-        "44"
+        "45"
     ],
     "url": "https://github.com/lyokha/g3kb-switch",
-    "version" : 1,
     "session-modes" : [
         "user",
         "unlock-dialog"


### PR DESCRIPTION
see https://gjs.guide/extensions/upgrading/gnome-shell-45.html

`"version" : 1,` is removed as it is confused when you see `1` after the extension name in `Extensions` app. None of my installed extensions actually use this feature. I will add it back if you think it is necessary.