### PR TITLE
Add a github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+---
+"on":
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+# https://github.com/softprops/action-gh-release/issues/236
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install rpm
+      - name: Build
+        run: |
+          cmake -Bbuild
+          cmake --build build
+          cmake --build build
+          # TODO: disable ctest because we haven't add any test
+          # ctest --test-dir build
+          cd build
+          cpack -G DEB
+          cpack -G RPM
+      # TODO: disable codecov because we disable ctest
+      # - uses: codecov/codecov-action@v3
+      #   with:
+      #     gcov: true
+      - uses: actions/upload-artifact@v3
+        if: "! startsWith(github.ref, 'refs/tags/')"
+        with:
+          path: |
+            build/*.deb
+            build/*.rpm
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/*.deb
+            build/*.rpm
+
+  deploy-aur:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: Freed-Wu/update-aur-package@v1.0.11
+        with:
+          package_name: g3kb-switch
+          ssh_private_key: ${{secrets.AUR_SSH_PRIVATE_KEY}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,17 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
 
 SET(name g3kb-switch)
 SET(HOMEPAGE_URL https://github.com/lyokha/g3kb-switch)
+# get version from git tag in github action
+STRING(REGEX MATCH [[[0-9](\.[0-9])*]] VERSION "$ENV{GITHUB_REF_NAME}")
+IF(NOT VERSION)
+    # a fallback
+    SET(VERSION 0.0.0.0)
+ENDIF()
 PROJECT(${name}
         LANGUAGES C
         HOMEPAGE_URL ${HOMEPAGE_URL}
         DESCRIPTION "CLI keyboard layout switcher for Gnome 3 and 4x"
-        VERSION 1.3)
+        VERSION ${VERSION})
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 INCLUDE(GNUInstallDirs)


### PR DESCRIPTION
After `git push --tags`,
a new deb and rpm will be published in github release.